### PR TITLE
modify ambiguous variable names

### DIFF
--- a/django_secrets/utils.py
+++ b/django_secrets/utils.py
@@ -11,7 +11,7 @@ class SettingKeyNotExists(Exception):
         return f'SettingKeyNotExists ({", ".join(self.names)})'
 
 
-def setting(names, default=None, settings_module=None, lookup_env=True, raise_exception=False):
+def setting(available_names, default=None, settings_module=None, lookup_env=True, raise_exception=False):
     """
     Helper function to get a Django setting by name. If setting doesn't exists
     it will return a default.
@@ -21,21 +21,21 @@ def setting(names, default=None, settings_module=None, lookup_env=True, raise_ex
         frame = stack[3][0]
         settings_module = inspect.getmodule(frame)
 
-    if not isinstance(names, Iterable):
-        names = [names]
+    if not isinstance(available_names, Iterable):
+        available_names = [available_names]
 
-    for name in names:
+    for name in available_names:
         value = getattr(settings_module, name, None)
         if value is not None:
             return value
 
     if lookup_env:
-        for name in names:
+        for name in available_names:
             value = os.environ.get(name)
             if value is not None:
                 return value
 
     if raise_exception:
-        raise SettingKeyNotExists(names)
+        raise SettingKeyNotExists(available_names)
 
     return default


### PR DESCRIPTION
The name 'names' seems ambiguous.
because it seemed to return a value for all names provided as 'names'.