### PR TITLE
Modify bug that repeats each character when a string comes

### DIFF
--- a/django_secrets/utils.py
+++ b/django_secrets/utils.py
@@ -21,7 +21,7 @@ def setting(available_names, default=None, settings_module=None, lookup_env=True
         frame = stack[3][0]
         settings_module = inspect.getmodule(frame)
 
-    if not isinstance(available_names, Iterable):
+    if isinstance(available_names, str) or not isinstance(available_names, Iterable):
         available_names = [available_names]
 
     for name in available_names:


### PR DESCRIPTION
repeat each character when came as string type


```python
    if not isinstance(names, Iterable):  # string passes this condition. (string also Iterable Type)
        names = [names]

    for name in names:
        value = getattr(settings_module, name, None)
        if value is not None:
            return value
```