### PR TITLE
ADD Util Setting Test

### DIFF
--- a/django_secrets/utils.py
+++ b/django_secrets/utils.py
@@ -21,7 +21,7 @@ def setting(available_names, default=None, settings_module=None, lookup_env=True
         frame = stack[3][0]
         settings_module = inspect.getmodule(frame)
 
-    if not isinstance(available_names, Iterable):
+    if isinstance(available_names, str) or not isinstance(available_names, Iterable):
         available_names = [available_names]
 
     for name in available_names:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,10 @@
 boto3
 django
 
+# install_develop_requirements
+pytest
+pytest-cov
+
 # PyPI deploy
 twine
 setuptools

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,55 @@
+import os
+
+import django
+import pytest
+from django.conf import settings
+
+from django_secrets.utils import setting, SettingKeyNotExists
+
+
+class TestSetting:
+
+    @classmethod
+    def setup_class(cls):
+        cls.AWS_SECRET_NAME = 'AWS Secret Key'
+        settings.configure(
+            DEBUG_PROPAGATE_EXCEPTIONS=True,
+            SECRET_KEY='Django Secret Key',
+            AWS_SECRET_NAME=cls.AWS_SECRET_NAME
+        )
+
+        django.setup()
+
+    def test_available_names_type_list_or_tuple(self):
+        value = setting(names=['AWS_SECRETS_MANAGER_SECRET_NAME', 'AWS_SECRET_NAME'], settings_module=settings)
+
+        assert value == self.AWS_SECRET_NAME
+
+        value = setting(names=('AWS_SECRETS_MANAGER_SECRET_NAME', 'AWS_SECRET_NAME',), settings_module=settings)
+
+        assert value == self.AWS_SECRET_NAME
+
+    def test_available_names_type_not_list(self):
+        value = setting(names='AWS_SECRET_NAME', settings_module=settings)
+
+        assert value == self.AWS_SECRET_NAME
+
+    def test_get_from_environ(self):
+        os.environ.setdefault('AWS_ENVIRON_SECRET_NAME', self.AWS_SECRET_NAME)
+        value = setting(names='AWS_ENVIRON_SECRET_NAME', settings_module=settings)
+
+        assert value ==self.AWS_SECRET_NAME
+
+    def test_key_not_exists(self):
+        value = setting(names='NOT_EXISTS_KEY', settings_module=settings)
+
+        assert value is None
+
+    def test_key_not_exists_get_default(self):
+        value = setting(names='NOT_EXISTS_KEY', default='Exists Key', settings_module=settings)
+
+        assert value == 'Exists Key'
+
+    def test_settings_key_not_exists_with_raise_exception(self):
+        with pytest.raises(SettingKeyNotExists, match=r'SettingKeyNotExists .*'):
+            setting(names='NOT_EXISTS_KEY', settings_module=settings, raise_exception=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -38,7 +38,7 @@ class TestSetting:
         os.environ.setdefault('AWS_ENVIRON_SECRET_NAME', self.AWS_SECRET_NAME)
         value = setting(names='AWS_ENVIRON_SECRET_NAME', settings_module=settings)
 
-        assert value ==self.AWS_SECRET_NAME
+        assert value == self.AWS_SECRET_NAME
 
     def test_key_not_exists(self):
         value = setting(names='NOT_EXISTS_KEY', settings_module=settings)


### PR DESCRIPTION
- Add Util Settings Test ( without `settings_moudle` not provided )
- There is a bug when `names` given as a string. ex ) `settings.config` => `[s, e, t, t, i, n, g, s, ...]`

# Help Wanted
- instantiate from `__init__` file, cannot run test. How should i change it?
- [if settings_module is None:](https://github.com/LeeHanYeong/django-secrets-manager/blob/2ff6afb8440fa32fbf0e648b5e3b2cb4904925f2/django_secrets/utils.py#L19) I don't know how to test this.
